### PR TITLE
レイアウトを調整し、ヘッダーに必要な情報のみを残すように修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,91 +1,39 @@
 <template>
-  <v-app dark>
-    <v-navigation-drawer
-      v-model="drawer"
-      :mini-variant="miniVariant"
-      :clipped="clipped"
-      fixed
-      app
-    >
-      <v-list>
-        <v-list-item
-          v-for="(item, i) in items"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
-          <v-list-item-action>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title v-text="item.title" />
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
-    <v-app-bar :clipped-left="clipped" fixed app>
-      <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <v-btn icon @click.stop="miniVariant = !miniVariant">
-        <v-icon>mdi-{{ `chevron-${miniVariant ? 'right' : 'left'}` }}</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="clipped = !clipped">
-        <v-icon>mdi-application</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="fixed = !fixed">
-        <v-icon>mdi-minus</v-icon>
-      </v-btn>
-      <v-toolbar-title v-text="title" />
-      <v-spacer />
-      <v-btn icon @click.stop="rightDrawer = !rightDrawer">
-        <v-icon>mdi-menu</v-icon>
-      </v-btn>
+  <v-app>
+    <v-app-bar app dark color="#3085DE">
+      <nuxt-link to="/" :class="$style.header_link">
+        <v-toolbar-title :class="$style.app_title">Uiita </v-toolbar-title>
+      </nuxt-link>
+      <v-spacer></v-spacer>
+      <v-btn text :class="$style.register">ユーザー登録</v-btn>
+      <v-btn text :class="$style.login">ログイン</v-btn>
     </v-app-bar>
     <v-main>
-      <v-container>
-        <Nuxt />
+      <v-container fluid :class="$style.container">
+        <nuxt />
       </v-container>
     </v-main>
-    <v-navigation-drawer v-model="rightDrawer" :right="right" temporary fixed>
-      <v-list>
-        <v-list-item @click.native="right = !right">
-          <v-list-item-action>
-            <v-icon light> mdi-repeat </v-icon>
-          </v-list-item-action>
-          <v-list-item-title>Switch drawer (click me)</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-navigation-drawer>
-    <v-footer :absolute="!fixed" app>
-      <span>&copy; {{ new Date().getFullYear() }}</span>
-    </v-footer>
   </v-app>
 </template>
 
-<script>
-export default {
-  data() {
-    return {
-      clipped: false,
-      drawer: false,
-      fixed: false,
-      items: [
-        {
-          icon: 'mdi-apps',
-          title: 'Welcome',
-          to: '/',
-        },
-        {
-          icon: 'mdi-chart-bubble',
-          title: 'Inspire',
-          to: '/inspire',
-        },
-      ],
-      miniVariant: false,
-      right: true,
-      rightDrawer: false,
-      title: 'Vuetify.js',
-    }
-  },
+<style lang="scss" module>
+.header_link {
+  text-decoration: none;
 }
-</script>
+.app_title {
+  color: #fff;
+  font-weight: bold;
+}
+.register {
+  border: 2px solid #fff;
+  border-radius: 5px;
+  font-weight: bold;
+}
+.login {
+  font-weight: bold;
+}
+.container {
+  background: #ecf6fe;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## 概要
 - `layouts/default.vue` からの不要な記述を削除
 - ヘッダーのデザインを [Vuetify のドキュメント](https://vuetifyjs.com/ja/components/app-bars/)  を見ながら調整
 - ヘッダーのタイトルにアプリ名を表示