### PR TITLE
リウエスト時に header 情報を常に送信する様に調整

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,8 +24,11 @@ export default {
   css: ['@fortawesome/fontawesome-free/css/all.css'],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: ['~/plugins/timeago.js', '~/plugins/cookie-storage.js'],
-
+  plugins: [
+    '~/plugins/timeago.js',
+    '~/plugins/cookie-storage.js',
+    '~/plugins/axios.js',
+  ],
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
 

--- a/pages/axios.js
+++ b/pages/axios.js
@@ -1,0 +1,11 @@
+export default function setup({ store }) {
+  store.$axios.interceptors.request.use((config) => {
+    let headers = {}
+    headers = store.getters['user/headers']
+    Object.keys(headers).forEach(function (key) {
+      const value = headers[key]
+      config.headers[key] = value
+    })
+    return config
+  })
+}


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 内容
 - この設定を行うと axios で API を叩く際のリクエストに header 情報（認証トークンなど）が自動でセットされる