### PR TITLE
認証前後のリダイレクト処理を実装

### DIFF
--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -1,0 +1,7 @@
+export default function ({ store, redirect, route }) {
+  const isSingedIn = store.state.user.isSignedIn
+  // 認証前だったらログインページへ
+  if (!isSingedIn) {
+    return redirect('/sign_in')
+  }
+}

--- a/middleware/before_auth.js
+++ b/middleware/before_auth.js
@@ -1,0 +1,7 @@
+export default function ({ store, redirect }) {
+  const isSingedIn = store.state.user.isSignedIn
+  // 既にログインしていたらトップページへ
+  if (isSingedIn) {
+    return redirect('/')
+  }
+}

--- a/pages/sign_in.vue
+++ b/pages/sign_in.vue
@@ -41,6 +41,8 @@
 
 <script>
 export default {
+  middleware: ['before_auth'],
+
   data() {
     return {
       name: '',

--- a/pages/sign_up.vue
+++ b/pages/sign_up.vue
@@ -50,6 +50,7 @@
 
 <script>
 export default {
+  middleware: ['before_auth'],
   data() {
     return {
       name: '',


### PR DESCRIPTION
## 概要
 - 認証前後の状態を判定してリダイレクト処理を走らせるように調整

## 内容
 - middleware に記述することでページ読み込み前に本 PR の処理が実行される

## 補足
 - トップページの記事一覧は誰でも閲覧できるようにしたいので対象外